### PR TITLE
[benchmark] enable constexpr predict benchmark

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -68,7 +68,7 @@ foreach(BENCHMARK "baseline.cpp" "predict_1x1x0.cpp" "predict_1x1x1.cpp"
            "--benchmark_out=${NAME}.json")
 endforeach()
 
-foreach(BACKEND IN ITEMS "eigen")
+foreach(BACKEND IN ITEMS "eigen" "naive")
   foreach(STATE_SIZE RANGE 1 2)
     foreach(INPUT_SIZE RANGE 1 2)
       configure_file(predict_linalg_x1x.cpp


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/FrancoisCarouge/Kalman/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in the following license file, and represent that you
have the right to do so:
https://github.com/FrancoisCarouge/Kalman/blob/master/LICENSE.txt
-->
