### PR TITLE
[benchmark] disable while Google Test is broken

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,6 @@ include(CPack)
 include(CTest)
 include(GNUInstallDirs)
 
-add_subdirectory("benchmark")
 add_subdirectory("cmake")
 add_subdirectory("include")
 add_subdirectory("linalg")


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/FrancoisCarouge/Kalman/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in the following license file, and represent that you
have the right to do so:
https://github.com/FrancoisCarouge/Kalman/blob/master/LICENSE.txt
-->

Google test, dependency on benchmark broken by:
https://github.com/google/googletest/commit/5a37b517ad4ab6738556f0284c256cae1466c5b4

Disable benchmarks for now, re-enable later, or replace benchmarking framework.