### PR TITLE
[utility] use std::tuple instead of reinventing a pack holding type

### DIFF
--- a/include/fcarouge/internal/factory.hpp
+++ b/include/fcarouge/internal/factory.hpp
@@ -85,7 +85,8 @@ template <typename Filter = void> struct filter_deducer {
   inline constexpr auto operator()(state<State> x,
                                    [[maybe_unused]] output_t<Output> z,
                                    [[maybe_unused]] input_t<Input> u) const {
-    using kt = x_z_u_p_q_r_us_ps<State, Output, Input, empty_pack, empty_pack>;
+    using kt =
+        x_z_u_p_q_r_us_ps<State, Output, Input, empty_tuple, empty_tuple>;
     return kt{typename kt::state{x.value}};
   }
 
@@ -106,7 +107,7 @@ template <typename Filter = void> struct filter_deducer {
              output_uncertainty<OutputUncertainty> r,
              state_transition<StateTransition> f, input_control<InputControl> g,
              [[maybe_unused]] prediction_types_t<Ps...> pts) const {
-    using kt = x_z_u_p_q_r_f_g_ps<State, Output, Input, empty_pack,
+    using kt = x_z_u_p_q_r_f_g_ps<State, Output, Input, empty_tuple,
                                   repack_t<prediction_types_t<Ps...>>>;
     return kt{typename kt::state{x.value},
               typename kt::estimate_uncertainty{p.value},
@@ -214,7 +215,8 @@ template <typename Filter = void> struct filter_deducer {
              estimate_uncertainty<EstimateUncertainty> p,
              process_uncertainty<ProcessUncertainty> q,
              output_uncertainty<OutputUncertainty> r) const {
-    using kt = x_z_u_p_q_r_us_ps<State, Output, Input, empty_pack, empty_pack>;
+    using kt =
+        x_z_u_p_q_r_us_ps<State, Output, Input, empty_tuple, empty_tuple>;
     return kt{typename kt::state{x.value},
               typename kt::estimate_uncertainty{p.value},
               typename kt::process_uncertainty{q.value},

--- a/include/fcarouge/internal/format.hpp
+++ b/include/fcarouge/internal/format.hpp
@@ -41,7 +41,9 @@ For more information, please refer to <https://unlicense.org> */
 
 #include "fcarouge/utility.hpp"
 
+#include <cstddef>
 #include <format>
+#include <tuple>
 #include <type_traits>
 
 template <fcarouge::kalman_filter Filter, typename Char>
@@ -84,9 +86,10 @@ struct std::formatter<Filter, Char> {
         format_context.out(), R"("k": {}, "p": {}, )", filter.k(), filter.p()));
 
     if constexpr (fcarouge::has_prediction_types<Filter>) {
-      constexpr auto end{fcarouge::size<typename Filter::prediction_types>};
-      constexpr decltype(end) begin{0};
-      constexpr decltype(end) next{1};
+      constexpr std::size_t end{
+          std::tuple_size_v<typename Filter::prediction_types>};
+      constexpr std::size_t begin{0};
+      constexpr std::size_t next{1};
       fcarouge::internal::for_constexpr<begin, end, next>(
           [&format_context, &filter](auto position) {
             format_context.advance_to(std::format_to(
@@ -117,9 +120,10 @@ struct std::formatter<Filter, Char> {
 
     //! @todo Inconsistent usage of internal?
     if constexpr (fcarouge::has_update_types<Filter>) {
-      constexpr auto end{fcarouge::size<typename Filter::update_types>};
-      constexpr decltype(end) begin{0};
-      constexpr decltype(end) next{1};
+      constexpr std::size_t end{
+          std::tuple_size_v<typename Filter::update_types>};
+      constexpr std::size_t begin{0};
+      constexpr std::size_t next{1};
       fcarouge::internal::for_constexpr<begin, end, next>(
           [&format_context, &filter](auto position) {
             format_context.advance_to(

--- a/include/fcarouge/internal/utility.hpp
+++ b/include/fcarouge/internal/utility.hpp
@@ -40,6 +40,7 @@ For more information, please refer to <https://unlicense.org> */
 #define FCAROUGE_INTERNAL_UTILITY_HPP
 
 #include <concepts>
+#include <tuple>
 #include <type_traits>
 
 namespace fcarouge::internal {
@@ -221,22 +222,16 @@ struct conditional_member_types : public conditional_input_control<Filter>,
                                   conditional_state_transition<Filter>,
                                   conditional_update_types<Filter> {};
 
-template <typename...> struct pack {};
-
 template <typename Type> struct repack {
   using type = Type;
 };
 
 template <template <typename...> typename Pack, typename... Types>
 struct repack<Pack<Types...>> {
-  using type = pack<Types...>;
+  using type = std::tuple<Types...>;
   using size_t = std::remove_const_t<decltype(sizeof...(Types))>;
 
   static inline constexpr auto size{sizeof...(Types)};
-};
-
-template <typename Type, typename... Types> struct first_type {
-  using type = Type;
 };
 
 template <auto Value, auto... Values> struct first_value {
@@ -291,13 +286,14 @@ template <typename Lhs, typename Rhs>
 using deduce_matrix =
     std::remove_cvref_t<std::invoke_result_t<matrix_deducer, Lhs, Rhs>>;
 
-using empty_pack = pack<>;
+using empty_tuple = std::tuple<>;
 
 template <typename Pack> using repack_t = repack<Pack>::type;
 
 template <typename Pack> using size_t = repack<Pack>::size_t;
 
-template <typename... Types> using first_t = first_type<Types...>::type;
+template <typename... Types>
+using first_t = std::tuple_element_t<0, std::tuple<Types...>>;
 
 template <auto Begin, decltype(Begin) End, decltype(Begin) Increment,
           typename Function>

--- a/include/fcarouge/internal/x_z_p_q_r_hh_us_ps.hpp
+++ b/include/fcarouge/internal/x_z_p_q_r_hh_us_ps.hpp
@@ -51,8 +51,8 @@ struct x_z_p_q_r_hh_us_ps final {};
 
 template <typename State, typename Output, typename... UpdateTypes,
           typename... PredictionTypes>
-struct x_z_p_q_r_hh_us_ps<State, Output, pack<UpdateTypes...>,
-                          pack<PredictionTypes...>> {
+struct x_z_p_q_r_hh_us_ps<State, Output, std::tuple<UpdateTypes...>,
+                          std::tuple<PredictionTypes...>> {
   using state = State;
   using output = Output;
   using estimate_uncertainty = deduce_matrix<state, state>;

--- a/include/fcarouge/internal/x_z_u_p_q_r_f_g_ps.hpp
+++ b/include/fcarouge/internal/x_z_u_p_q_r_f_g_ps.hpp
@@ -51,8 +51,8 @@ struct x_z_u_p_q_r_f_g_ps final {};
 
 template <typename State, typename Output, typename Input,
           typename... UpdateTypes, typename... PredictionTypes>
-struct x_z_u_p_q_r_f_g_ps<State, Output, Input, pack<UpdateTypes...>,
-                          pack<PredictionTypes...>> {
+struct x_z_u_p_q_r_f_g_ps<State, Output, Input, std::tuple<UpdateTypes...>,
+                          std::tuple<PredictionTypes...>> {
   using state = State;
   using output = Output;
   using input = Input;

--- a/include/fcarouge/internal/x_z_u_p_q_r_us_ps.hpp
+++ b/include/fcarouge/internal/x_z_u_p_q_r_us_ps.hpp
@@ -51,8 +51,8 @@ struct x_z_u_p_q_r_us_ps final {};
 
 template <typename State, typename Output, typename Input,
           typename... UpdateTypes, typename... PredictionTypes>
-struct x_z_u_p_q_r_us_ps<State, Output, Input, pack<UpdateTypes...>,
-                         pack<PredictionTypes...>> {
+struct x_z_u_p_q_r_us_ps<State, Output, Input, std::tuple<UpdateTypes...>,
+                         std::tuple<PredictionTypes...>> {
   using state = State;
   using output = Output;
   using input = Input;

--- a/include/fcarouge/kalman.hpp
+++ b/include/fcarouge/kalman.hpp
@@ -490,7 +490,7 @@ public:
   //! argument types.
   //!
   //! @return The prediction argument corresponding to the Nth position of the
-  //! parameter pack of the tuple-like `PredictionTypes` class template type.
+  //! parameter pack of the tuple `PredictionTypes` class template type.
   //!
   //! @complexity Constant.
   template <std::size_t Position> inline constexpr auto predict() const;
@@ -523,7 +523,7 @@ public:
   //! argument types.
   //!
   //! @return The update argument corresponding to the Nth position of the
-  //! parameter pack of the tuple-like `UpdateTypes` class template type.
+  //! parameter pack of the tuple `UpdateTypes` class template type.
   //!
   //! @complexity Constant.
   template <std::size_t Position> inline constexpr auto update() const;

--- a/include/fcarouge/utility.hpp
+++ b/include/fcarouge/utility.hpp
@@ -136,21 +136,15 @@ concept has_output_model = internal::has_output_model<Filter>;
 //! @name Types
 //! @{
 
-//! @brief Tuple-like pack type.
+//! @brief Type of the empty tuple.
 //!
-//! @details An alternative to tuple-like types.
-template <typename... Types> using pack = internal::pack<Types...>;
-
-//! @brief Tuple-like empty pack type.
-//!
-//! @details A `pack` type with no composed types.
-using empty_pack = internal::empty_pack;
+//! @details A tuple with no `pack` types.
+using empty_tuple = internal::empty_tuple;
 
 //! @brief Unpack the first type of the type template parameter pack.
+//!
+//! @details Shorthand for `std::tuple_element_t<0, std::tuple<Types...>>`.
 template <typename... Types> using first_t = internal::first_t<Types...>;
-
-//! @brief Type of the count of the types in the pack.
-template <typename Pack> using size_t = internal::size_t<Pack>;
 
 //! @brief The matrix type satisfying `X * Row = Column`.
 //!
@@ -183,9 +177,6 @@ constexpr auto operator/(const Numerator &lhs, const Denominator &rhs)
 //! @brief Unpack the first value of the non-type template parameter pack.
 template <auto... Values>
 inline constexpr auto first_v{internal::first_v<Values...>};
-
-//! @brief Count the packed types.
-template <typename Pack> inline constexpr auto size{internal::size<Pack>};
 
 //! @brief The identity matrix.
 //!


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/FrancoisCarouge/Kalman/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in the following license file, and represent that you
have the right to do so:
https://github.com/FrancoisCarouge/Kalman/blob/master/LICENSE.txt
-->
