### PR TITLE
[cmake] fix compiler options ordering for mp-units

### DIFF
--- a/sample/sample.cmake
+++ b/sample/sample.cmake
@@ -61,8 +61,7 @@ function(sample)
                      "${SAMPLE_NAME}.cpp")
       target_link_libraries(
         kalman_sample_${BACKEND}_${SAMPLE_NAME}_driver
-        PRIVATE kalman kalman_main kalman_linalg_${BACKEND} kalman_options
-                kalman_unit_mp_units)
+        PRIVATE kalman kalman_main kalman_linalg_${BACKEND} kalman_options)
       separate_arguments(SAMPLE_COMMAND UNIX_COMMAND $ENV{COMMAND})
       add_test(
         NAME kalman_sample_${BACKEND}_${SAMPLE_NAME}

--- a/support/mp_units/CMakeLists.txt
+++ b/support/mp_units/CMakeLists.txt
@@ -53,12 +53,11 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(mp-units)
 
 target_compile_options(mp-units INTERFACE $<IF:$<CXX_COMPILER_ID:MSVC>, ,
-                                          -Wno-double-promotion>)
-target_compile_options(mp-units INTERFACE $<IF:$<CXX_COMPILER_ID:MSVC>, ,
-                                          -Wno-undef>)
+                                          -Wno-double-promotion -Wno-undef>)
 
 add_library(kalman_unit_mp_units INTERFACE)
 target_sources(
   kalman_unit_mp_units INTERFACE FILE_SET "unit_headers" TYPE "HEADERS" FILES
                                  "fcarouge/unit.hpp")
-target_link_libraries(kalman_unit_mp_units INTERFACE mp-units::mp-units)
+target_link_libraries(kalman_unit_mp_units INTERFACE kalman_options
+                                                     mp-units::mp-units)


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/FrancoisCarouge/Kalman/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in the following license file, and represent that you
have the right to do so:
https://github.com/FrancoisCarouge/Kalman/blob/master/LICENSE.txt
-->
