### PR TITLE
[utility] use standard operator function object naming convention

### DIFF
--- a/include/fcarouge/internal/utility.hpp
+++ b/include/fcarouge/internal/utility.hpp
@@ -248,9 +248,6 @@ template <typename Type> struct not_implemented {
   static_assert(missing, "This type is not implemented. See compiler message.");
 };
 
-template <typename Lhs, typename Rhs>
-using product = decltype(std::declval<Lhs>() * std::declval<Rhs>());
-
 using empty_tuple = std::tuple<>;
 
 template <typename Pack> using repack = repacker<Pack>::type;

--- a/include/fcarouge/internal/x_z_p_r_f.hpp
+++ b/include/fcarouge/internal/x_z_p_r_f.hpp
@@ -50,7 +50,7 @@ template <typename State> struct x_z_p_r_f {
   using state_transition = ᴀʙᵀ<state, state>;
   using innovation = output;
   using innovation_uncertainty = output_uncertainty;
-  using gain = evaluate<divide<estimate_uncertainty, innovation_uncertainty>>;
+  using gain = evaluate<quotient<estimate_uncertainty, innovation_uncertainty>>;
 
   static inline const auto i{one<gain>};
 

--- a/include/fcarouge/utility.hpp
+++ b/include/fcarouge/utility.hpp
@@ -133,7 +133,7 @@ concept has_output_model = internal::has_output_model<Filter>;
 //! @name Types
 //! @{
 
-//! @brief Linear algebra divider expression type specialization point.
+//! @brief Linear algebra divides expression type specialization point.
 //!
 //! @details Matrix division is a mathematical abuse of terminology. Informally
 //! defined as multiplication by the inverse. Similarly to division by zero in
@@ -143,27 +143,27 @@ concept has_output_model = internal::has_output_model<Filter>;
 //! ways to decompose and solve the equation. Implementations trade off
 //! numerical stability, triangularity, symmetry, space, time, etc. Dividing an
 //! `R1 x C` matrix by an `R2 x C` matrix results in an `R1 x R2` matrix.
-template <typename Lhs, typename Rhs> struct divider {
+template <typename Lhs, typename Rhs> struct divides {
   [[nodiscard]] inline constexpr auto
   operator()(const Lhs &lhs, const Rhs &rhs) const -> decltype(lhs / rhs);
 };
 
 //! @brief Divider helper type.
 template <typename Lhs, typename Rhs>
-using divide =
-    std::invoke_result_t<divider<Lhs, Rhs>, const Lhs &, const Rhs &>;
+using quotient =
+    std::invoke_result_t<divides<Lhs, Rhs>, const Lhs &, const Rhs &>;
 
-//! @brief Linear algebra evaluater override expression lazy evaluation
+//! @brief Linear algebra evaluates override expression lazy evaluation
 //! specialization point.
-template <typename Type> struct evaluater {
+template <typename Type> struct evaluates {
   [[nodiscard]] inline constexpr auto operator()() const -> Type;
 };
 
 //! @brief Evaluater helper type.
-template <typename Type> using evaluate = std::invoke_result_t<evaluater<Type>>;
+template <typename Type> using evaluate = std::invoke_result_t<evaluates<Type>>;
 
-//! @brief Linear algebra transposer specialization point.
-template <typename Type> struct transposer {
+//! @brief Linear algebra transposes specialization point.
+template <typename Type> struct transposes {
   [[nodiscard]] inline constexpr auto operator()(const Type &value) const {
     return value;
   }
@@ -171,7 +171,7 @@ template <typename Type> struct transposer {
 
 template <typename Type>
   requires requires(Type value) { value.transpose(); }
-struct transposer<Type> {
+struct transposes<Type> {
   [[nodiscard]] inline constexpr auto operator()(const Type &value) const {
     return value.transpose();
   }
@@ -179,13 +179,13 @@ struct transposer<Type> {
 
 //! @brief Transposer helper type.
 template <typename Type>
-using transpose = std::invoke_result_t<transposer<Type>, const Type &>;
+using transpose = std::invoke_result_t<transposes<Type>, const Type &>;
 
 //! @brief Transpose helper function.
 //!
 //! @details Enable readable linear algebra notation.
 template <typename Type> auto t(const Type &value) {
-  return transposer<Type>{}(value);
+  return transposes<Type>{}(value);
 }
 
 //! @brief Type of the empty tuple.
@@ -202,9 +202,16 @@ template <typename... Types> using first = internal::first<Types...>;
 template <typename Type, std::size_t Size>
 using tuple_n_type = internal::tuple_n_type<Type, Size>;
 
-//! @brief The deduced result type of the product.
+//! @brief Type multiplies expression type specialization point.
+template <typename Lhs, typename Rhs> struct multiplies {
+  [[nodiscard]] inline constexpr auto
+  operator()(const Lhs &lhs, const Rhs &rhs) const -> decltype(lhs * rhs);
+};
+
+//! @brief Helper type to deduce the result type of the product.
 template <typename Lhs, typename Rhs>
-using product = internal::product<Lhs, Rhs>;
+using product =
+    std::invoke_result_t<multiplies<Lhs, Rhs>, const Lhs &, const Rhs &>;
 
 //! @brief The evaluated type of the ABᵀ expression.
 template <typename Lhs, typename Rhs>

--- a/support/eigen/fcarouge/eigen.hpp
+++ b/support/eigen/fcarouge/eigen.hpp
@@ -90,13 +90,13 @@ using column_vector = Eigen::Vector<Type, Row>;
 
 namespace fcarouge {
 //! @brief Specialization of the evaluation type.
-template <eigen::is_eigen Type> struct evaluater<Type> {
+template <eigen::is_eigen Type> struct evaluates<Type> {
   [[nodiscard]] inline constexpr auto operator()() const ->
       typename Type::PlainMatrix;
 };
 
 //! @brief Specialization of the division type.
-template <eigen::is_eigen Lhs, eigen::is_eigen Rhs> struct divider<Lhs, Rhs> {
+template <eigen::is_eigen Lhs, eigen::is_eigen Rhs> struct divides<Lhs, Rhs> {
   [[nodiscard]] inline constexpr auto operator()(const Lhs &lhs, const Rhs &rhs)
       const -> eigen::matrix<typename Rhs::Scalar, Lhs::RowsAtCompileTime,
                              Rhs::RowsAtCompileTime>;
@@ -113,7 +113,7 @@ namespace Eigen {
 template <fcarouge::eigen::is_eigen Numerator,
           fcarouge::eigen::is_eigen Denominator>
 constexpr auto operator/(const Numerator &lhs, const Denominator &rhs)
-    -> fcarouge::divide<Numerator, Denominator> {
+    -> fcarouge::quotient<Numerator, Denominator> {
   return rhs.transpose()
       .fullPivHouseholderQr()
       .solve(lhs.transpose())

--- a/support/indexed/fcarouge/indexed.hpp
+++ b/support/indexed/fcarouge/indexed.hpp
@@ -421,7 +421,7 @@ template <typename Matrix1, typename Matrix2, typename RowIndexes1,
 [[nodiscard]] inline constexpr auto
 operator/(const matrix<Matrix1, RowIndexes1, ColumnIndexes> &lhs,
           const matrix<Matrix2, RowIndexes2, ColumnIndexes> &rhs) {
-  return matrix<evaluate<divide<Matrix1, Matrix2>>, RowIndexes1, RowIndexes2>{
+  return matrix<evaluate<quotient<Matrix1, Matrix2>>, RowIndexes1, RowIndexes2>{
       lhs.data / rhs.data};
 }
 
@@ -526,18 +526,18 @@ namespace fcarouge {
 //! @note Implementation not needed.
 template <template <typename, typename, typename> typename IndexedMatrix,
           typename Matrix, typename RowIndexes, typename ColumnIndexes>
-struct evaluater<IndexedMatrix<Matrix, RowIndexes, ColumnIndexes>> {
+struct evaluates<IndexedMatrix<Matrix, RowIndexes, ColumnIndexes>> {
   [[nodiscard]] inline constexpr auto operator()() const
       -> IndexedMatrix<evaluate<Matrix>, RowIndexes, ColumnIndexes>;
 };
 
-//! @brief Specialization of the transposer.
+//! @brief Specialization of the transposes.
 template <template <typename, typename, typename> typename IndexedMatrix,
           typename Matrix, typename RowIndexes, typename ColumnIndexes>
   requires requires(IndexedMatrix<Matrix, RowIndexes, ColumnIndexes> m) {
     m.data;
   }
-struct transposer<IndexedMatrix<Matrix, RowIndexes, ColumnIndexes>> {
+struct transposes<IndexedMatrix<Matrix, RowIndexes, ColumnIndexes>> {
   [[nodiscard]] inline constexpr auto operator()(
       const IndexedMatrix<Matrix, RowIndexes, ColumnIndexes> &value) const {
     return IndexedMatrix<evaluate<transpose<Matrix>>, ColumnIndexes,

--- a/support/naive/fcarouge/naive.hpp
+++ b/support/naive/fcarouge/naive.hpp
@@ -417,14 +417,14 @@ namespace fcarouge {
 //!
 //! @note Implementation not needed.
 template <typename Type, std::size_t Row, std::size_t Column>
-struct evaluater<naive::matrix<Type, Row, Column>> {
+struct evaluates<naive::matrix<Type, Row, Column>> {
   [[nodiscard]] inline constexpr auto
   operator()() const -> naive::matrix<Type, Row, Column>;
 };
 
-//! @brief Specialization of the transposer.
+//! @brief Specialization of the transposes.
 template <typename Type, std::size_t Row, std::size_t Column>
-struct transposer<naive::matrix<Type, Row, Column>> {
+struct transposes<naive::matrix<Type, Row, Column>> {
   [[nodiscard]] inline constexpr auto
   operator()(const naive::matrix<Type, Row, Column> &value) const {
     naive::matrix<Type, Column, Row> result;


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/FrancoisCarouge/Kalman/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in the following license file, and represent that you
have the right to do so:
https://github.com/FrancoisCarouge/Kalman/blob/master/LICENSE.txt
-->
