### PR TITLE
[linalg] remove unecessary typed linear algebra specialization

### DIFF
--- a/support/eigexed/fcarouge/linalg.hpp
+++ b/support/eigexed/fcarouge/linalg.hpp
@@ -48,7 +48,8 @@ For more information, please refer to <https://unlicense.org> */
 
 #include <cstddef>
 
-namespace fcarouge::kalman_internal {
+namespace fcarouge {
+namespace kalman_internal {
 //! @brief Specialization of the evaluation type.
 //!
 //! @note Implementation not needed.
@@ -83,17 +84,7 @@ inline typed_matrix<decltype(zero<Matrix>), RowIndexes, ColumnIndexes>
 
 //! @}
 
-} // namespace fcarouge::kalman_internal
-
-namespace fcarouge::typed_linear_algebra_internal {
-//! @brief Specialization of the evaluation type.
-template <eigen::is_eigen Type> struct evaluates<Type> {
-  [[nodiscard]] inline constexpr auto operator()() const ->
-      typename Type::PlainMatrix;
-};
-} // namespace fcarouge::typed_linear_algebra_internal
-
-namespace fcarouge {
+} // namespace kalman_internal
 
 //! @name Types
 //! @{


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/FrancoisCarouge/Kalman/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in the following license file, and represent that you
have the right to do so:
https://github.com/FrancoisCarouge/Kalman/blob/master/LICENSE.txt
-->
